### PR TITLE
사진 찍은 결과 뷰 UI 및 다시찍기 기능 구현

### DIFF
--- a/NalssiOtjang/Core/CaptureSession/Sources/CaptureSessionManager.swift
+++ b/NalssiOtjang/Core/CaptureSession/Sources/CaptureSessionManager.swift
@@ -97,7 +97,7 @@ extension CaptureSessionManager: AVCapturePhotoCaptureDelegate {
             self.continuation = nil
         }
         
-        if let error = error {
+        if let error {
             continuation?.resume(throwing: error)
             return
         }

--- a/NalssiOtjang/Feature/RecordPhoto/Package.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Package.swift
@@ -18,6 +18,10 @@ let package = Package(
             path: "../Shared/DesignSystem"
         ),
         .package(
+            name: "CoreCaptureSessionInterface",
+            path: "../Core/CaptureSession"
+        ),
+        .package(
             name: "CoreRouterInterface",
             path: "../Core/Router"
         ),
@@ -41,6 +45,10 @@ let package = Package(
                 .product(
                     name: "CoreRouterInterface",
                     package: "CoreRouterInterface"
+                ),
+                .product(
+                    name: "CoreCaptureSessionInterface",
+                    package: "CoreCaptureSessionInterface"
                 ),
                 .product(
                     name: "CoreLog",

--- a/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/CaptureCameraView.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/CaptureCameraView.swift
@@ -10,7 +10,7 @@ import SharedDesignSystem
 
 struct CaptureCameraView: View {
     
-    private let viewModel: CaptureCameraViewModel
+    @Bindable private var viewModel: CaptureCameraViewModel
     
     init(viewModel: CaptureCameraViewModel) {
         self.viewModel = viewModel
@@ -21,32 +21,47 @@ struct CaptureCameraView: View {
             if let capturedImage = viewModel.output.capturedImage {
                 CapturedCameraView(
                     capturedImage: capturedImage,
-                    retakeButtonTapped: {
-                        viewModel.action(.retakeButtonTapped)
-                    },
-                    usePhotoButtonTapped: {
-                        viewModel.action(.usePhotoButtonTapped)
-                    }
+                    onRetake: { viewModel.action(.retakeButtonTapped) },
+                    onUsePhoto: { viewModel.action(.usePhotoButtonTapped) }
                 )
             } else {
                 LiveCameraView(
                     isAuthorized: viewModel.output.isAuthorized,
-                    isShowTutorialAlert: viewModel.output.isShowTutorialAlert,
+                    isShowingTutorialAlert: viewModel.output.isShowingTutorialAlert,
                     sessionManager: viewModel.captureSessionManager,
-                    isShowBottomToolBar: viewModel.output.isShowBottomToolBar,
-                    captureButtonTapped: {
-                        viewModel.action(.captureButtonTapped)
-                    }, tutorialOKButtonTapped: {
-                        viewModel.action(.tutorialOkButtonTapped)
-                    }, switchButtonTapped: {
-                        viewModel.action(.switchButtonTapped)
-                    }, xButtonTapped: {
-                        viewModel.action(.xButtonTapped)
-                    }
+                    isShowingBottomToolBar: viewModel.output.isShowingBottomToolBar,
+                    onCapture: { viewModel.action(.captureButtonTapped) },
+                    onTutorialOK: { viewModel.action(.tutorialOkButtonTapped) },
+                    onSwitchCameara: { viewModel.action(.switchButtonTapped) },
+                    onDismissCamera: { viewModel.action(.xButtonTapped) }
                 )
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .alert(isPresented: $viewModel.output.isShowingErrorAlet) {
+            Alert(
+                title: Text(Constant.ErrorAlert.title),
+                message: Text(Constant.ErrorAlert.message),
+                dismissButton: .default(
+                    Text(Constant.ErrorAlert.buttonTitle),
+                    action: {
+                        viewModel.action(.errorAlertButtonTapped)
+                    }
+                )
+            )
+        }
         .setBackgroundBlackIgnoreSafeArea()
+    }
+}
+
+// MARK: - Constant
+
+extension CaptureCameraView {
+    fileprivate enum Constant {
+        enum ErrorAlert {
+            static let title: String = "오류"
+            static let message: String = "사진 촬영 도중 예상치 못한 오류가 발생했습니다. 다시 시도해 주세요."
+            static let buttonTitle: String = "확인"
+        }
     }
 }

--- a/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/CaptureCameraView.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/CaptureCameraView.swift
@@ -18,106 +18,35 @@ struct CaptureCameraView: View {
     
     var body: some View {
         ZStack {
-            VStack(spacing: Constant.RootVStack.spacing) {
-                
-                if !viewModel.output.isShowTutorialAlert {
-                    Text(Constant.ExplainText.text)
-                        .foregroundStyle(Color.customColor(.neutral(.white)))
-                        .padding(.top, Constant.ExplainText.topPadding)
-                }
-                
-                if viewModel.output.isAuthorized {
-                    CameraPreview(session: viewModel.captureSessionManager.captureSession)
-                }
-                
-                Spacer()
-                
-                Button {
-                    viewModel.action(.captureButtonTapped)
-                } label: {
-                    Circle()
-                        .stroke(Color.customColor(.neutral(.darkGray)), lineWidth: Constant.CaptureButton.lineWidth)
-                        .fill(Color.customColor(.neutral(.white)))
-                        .frame(width: Constant.CaptureButton.size, height: Constant.CaptureButton.size)
-                }
-            }
-            
-            if viewModel.output.isAuthorized && viewModel.output.isShowTutorialAlert {
-                NOAlertView(
-                    title: Constant.AlertView.title,
-                    image: NOImage.normal(.recordPhoto(.recordPhotoExpain)).image,
-                    buttonText: Constant.AlertView.buttonTitle
-                ) {
-                    withAnimation(.easeInOut(duration: Constant.AlertView.animationDuration)) {
-                        viewModel.action(.tutorialOkButtonTapped)
+            if let capturedImage = viewModel.output.capturedImage {
+                CapturedCameraView(
+                    capturedImage: capturedImage,
+                    retakeButtonTapped: {
+                        viewModel.action(.retakeButtonTapped)
+                    },
+                    usePhotoButtonTapped: {
+                        viewModel.action(.usePhotoButtonTapped)
                     }
-                }
-                .zIndex(1)
+                )
+            } else {
+                LiveCameraView(
+                    isAuthorized: viewModel.output.isAuthorized,
+                    isShowTutorialAlert: viewModel.output.isShowTutorialAlert,
+                    sessionManager: viewModel.captureSessionManager,
+                    isShowBottomToolBar: viewModel.output.isShowBottomToolBar,
+                    captureButtonTapped: {
+                        viewModel.action(.captureButtonTapped)
+                    }, tutorialOKButtonTapped: {
+                        viewModel.action(.tutorialOkButtonTapped)
+                    }, switchButtonTapped: {
+                        viewModel.action(.switchButtonTapped)
+                    }, xButtonTapped: {
+                        viewModel.action(.xButtonTapped)
+                    }
+                )
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.customColor(.neutral(.black)))
-        .toolbar {
-            ToolbarItem(placement: .bottomBar) {
-                NOToolBarButton(
-                    image: Image(systemName: Constant.ToolBarButton.xButtonimageName),
-                    imageSize: Constant.ToolBarButton.xButtonImageSize,
-                    foregroundColor: .customColor(.neutral(.white))) {
-                        viewModel.action(.xButtonTapped)
-                    }
-            }
-            .sharedBackgroundVisibility(.hidden)
-            
-            ToolbarSpacer(.flexible, placement: .bottomBar)
-            
-            ToolbarItem(placement: .bottomBar) {
-                NOToolBarButton(
-                    image: Image(systemName: Constant.ToolBarButton.switchButtonimageName),
-                    imageSize: Constant.ToolBarButton.switchButtonImageSize,
-                    foregroundColor: .customColor(.neutral(.white))) {
-                        viewModel.action(.switchButtonTapped)
-                    }
-            }
-            .sharedBackgroundVisibility(.hidden)
-        }
-        .toolbar(viewModel.output.isShowTutorialAlert ? .hidden : .visible, for: .bottomBar)
+        .setBackgroundBlackIgnoreSafeArea()
     }
 }
-
-// MARK: - Constant
-
-extension CaptureCameraView {
-    fileprivate enum Constant {
-        enum RootVStack {
-            static let spacing: CGFloat = 10
-        }
-        
-        enum ExplainText {
-            static let text: String = "옷이 잘 보이도록 사진을 찍어주세요"
-            static let topPadding: CGFloat = 20
-        }
-        
-        enum CameraPreview {
-            static let topPadding: CGFloat = 10
-        }
-        
-        enum CaptureButton {
-            static let lineWidth: CGFloat = 10
-            static let size: CGFloat = 60
-        }
-        
-        enum AlertView {
-            static let title: String = "옷이 잘 보이도록 사진을 찍어주세요!"
-            static let buttonTitle: String = "확인"
-            static let animationDuration: TimeInterval = 0.2
-        }
-        
-        enum ToolBarButton {
-            static let xButtonimageName: String = "xmark"
-            static let xButtonImageSize: CGSize = .init(width: 18, height: 18)
-            static let switchButtonimageName: String = "arrow.trianglehead.2.clockwise.rotate.90"
-            static let switchButtonImageSize: CGSize = .init(width: 26, height: 22)
-        }
-    }
-}
-

--- a/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/CapturedCameraView.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/CapturedCameraView.swift
@@ -1,0 +1,61 @@
+//
+//  CapturedCamearaView.swift
+//  FeatureRecordPhoto
+//
+//  Created by 정지훈 on 9/29/25.
+//
+
+import SwiftUI
+import SharedDesignSystem
+
+struct CapturedCameraView: View {
+    
+    let capturedImage: UIImage
+    let retakeButtonTapped: () -> Void
+    let usePhotoButtonTapped: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Image(uiImage: capturedImage)
+                .resizable()
+                .scaledToFit()
+                .padding(.top, Constant.CapturedImage.topPadding)
+            
+            Spacer()
+            
+            HStack {
+                Button(action: retakeButtonTapped) {
+                    Text(Constant.Button.reTakeButtonTitle)
+                        .foregroundStyle(Color.customColor(.neutral(.white)))
+                }
+                
+                Spacer()
+                
+                Button(action: usePhotoButtonTapped) {
+                    Text(Constant.Button.usePhotoButtonTitle)
+                        .foregroundStyle(Color.customColor(.neutral(.white)))
+                }
+
+            }
+            .padding(.horizontal, Constant.Button.buttonHorizontalPadding)
+            .padding(.bottom, Constant.Button.buttonBottomPadding)
+        }
+    }
+}
+
+// MARK: - Constant
+
+extension CapturedCameraView {
+    fileprivate enum Constant {
+        enum CapturedImage {
+            static let topPadding: CGFloat = 80
+        }
+        
+        enum Button {
+            static let reTakeButtonTitle: String = "다시 찍기"
+            static let usePhotoButtonTitle: String = "사진 사용"
+            static let buttonHorizontalPadding: CGFloat = 30
+            static let buttonBottomPadding: CGFloat = 20
+        }
+    }
+}

--- a/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/CapturedCameraView.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/CapturedCameraView.swift
@@ -11,8 +11,8 @@ import SharedDesignSystem
 struct CapturedCameraView: View {
     
     let capturedImage: UIImage
-    let retakeButtonTapped: () -> Void
-    let usePhotoButtonTapped: () -> Void
+    let onRetake: () -> Void
+    let onUsePhoto: () -> Void
     
     var body: some View {
         VStack(spacing: 0) {
@@ -24,14 +24,14 @@ struct CapturedCameraView: View {
             Spacer()
             
             HStack {
-                Button(action: retakeButtonTapped) {
+                Button(action: onRetake) {
                     Text(Constant.Button.reTakeButtonTitle)
                         .foregroundStyle(Color.customColor(.neutral(.white)))
                 }
                 
                 Spacer()
                 
-                Button(action: usePhotoButtonTapped) {
+                Button(action: onUsePhoto) {
                     Text(Constant.Button.usePhotoButtonTitle)
                         .foregroundStyle(Color.customColor(.neutral(.white)))
                 }

--- a/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/LiveCameraView.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/LiveCameraView.swift
@@ -13,8 +13,11 @@ struct LiveCameraView: View {
     let isAuthorized: Bool
     let isShowTutorialAlert: Bool
     let sessionManager: CaptureSessionable
-    let onCapture: () -> Void
-    let onTutorialOK: () -> Void
+    let isShowBottomToolBar: Bool
+    let captureButtonTapped: () -> Void
+    let tutorialOKButtonTapped: () -> Void
+    let switchButtonTapped: () -> Void
+    let xButtonTapped: () -> Void
 
     var body: some View {
         ZStack {
@@ -26,12 +29,12 @@ struct LiveCameraView: View {
                 }
 
                 if isAuthorized {
-                    CameraPreview(session: session)
+                    CameraPreview(session: sessionManager.captureSession)
                 }
 
                 Spacer()
 
-                Button(action: onCapture) {
+                Button(action: captureButtonTapped) {
                     Circle()
                         .stroke(Color.customColor(.neutral(.darkGray)),
                                 lineWidth: Constant.CaptureButton.lineWidth)
@@ -48,16 +51,42 @@ struct LiveCameraView: View {
                     buttonText: Constant.AlertView.buttonTitle
                 ) {
                     withAnimation(.easeInOut(duration: Constant.AlertView.animationDuration)) {
-                        onTutorialOK()
+                        tutorialOKButtonTapped()
                     }
                 }
                 .zIndex(1)
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .bottomBar) {
+                NOToolBarButton(
+                    image: Image(systemName: Constant.ToolBarButton.xButtonimageName),
+                    imageSize: Constant.ToolBarButton.xButtonImageSize,
+                    foregroundColor: .customColor(.neutral(.white))) {
+                        xButtonTapped()
+                    }
+            }
+            .sharedBackgroundVisibility(.hidden)
+            
+            ToolbarSpacer(.flexible, placement: .bottomBar)
+            
+            ToolbarItem(placement: .bottomBar) {
+                NOToolBarButton(
+                    image: Image(systemName: Constant.ToolBarButton.switchButtonimageName),
+                    imageSize: Constant.ToolBarButton.switchButtonImageSize,
+                    foregroundColor: .customColor(.neutral(.white))) {
+                        switchButtonTapped()
+                    }
+            }
+            .sharedBackgroundVisibility(.hidden)
+        }
+        .toolbar(isShowBottomToolBar ? .hidden : .visible, for: .bottomBar)
     }
 }
 
-extension CameraLiveView {
+// MARK: - Constant
+
+extension LiveCameraView {
     fileprivate enum Constant {
         enum RootVStack {
             static let spacing: CGFloat = 10

--- a/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/LiveCameraView.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/LiveCameraView.swift
@@ -11,18 +11,18 @@ import CoreCaptureSessionInterface
 
 struct LiveCameraView: View {
     let isAuthorized: Bool
-    let isShowTutorialAlert: Bool
+    let isShowingTutorialAlert: Bool
     let sessionManager: CaptureSessionable
-    let isShowBottomToolBar: Bool
-    let captureButtonTapped: () -> Void
-    let tutorialOKButtonTapped: () -> Void
-    let switchButtonTapped: () -> Void
-    let xButtonTapped: () -> Void
+    let isShowingBottomToolBar: Bool
+    let onCapture: () -> Void
+    let onTutorialOK: () -> Void
+    let onSwitchCameara: () -> Void
+    let onDismissCamera: () -> Void
 
     var body: some View {
         ZStack {
             VStack(spacing: Constant.RootVStack.spacing) {
-                if !isShowTutorialAlert {
+                if !isShowingTutorialAlert {
                     Text(Constant.ExplainText.text)
                         .foregroundStyle(Color.customColor(.neutral(.white)))
                         .padding(.top, Constant.ExplainText.topPadding)
@@ -34,7 +34,7 @@ struct LiveCameraView: View {
 
                 Spacer()
 
-                Button(action: captureButtonTapped) {
+                Button(action: onCapture) {
                     Circle()
                         .stroke(Color.customColor(.neutral(.darkGray)),
                                 lineWidth: Constant.CaptureButton.lineWidth)
@@ -44,14 +44,14 @@ struct LiveCameraView: View {
                 }
             }
 
-            if isAuthorized && isShowTutorialAlert {
+            if isAuthorized && isShowingTutorialAlert {
                 NOAlertView(
                     title: Constant.AlertView.title,
                     image: NOImage.normal(.recordPhoto(.recordPhotoExpain)).image,
                     buttonText: Constant.AlertView.buttonTitle
                 ) {
                     withAnimation(.easeInOut(duration: Constant.AlertView.animationDuration)) {
-                        tutorialOKButtonTapped()
+                        onTutorialOK()
                     }
                 }
                 .zIndex(1)
@@ -63,7 +63,7 @@ struct LiveCameraView: View {
                     image: Image(systemName: Constant.ToolBarButton.xButtonimageName),
                     imageSize: Constant.ToolBarButton.xButtonImageSize,
                     foregroundColor: .customColor(.neutral(.white))) {
-                        xButtonTapped()
+                        onDismissCamera()
                     }
             }
             .sharedBackgroundVisibility(.hidden)
@@ -75,12 +75,12 @@ struct LiveCameraView: View {
                     image: Image(systemName: Constant.ToolBarButton.switchButtonimageName),
                     imageSize: Constant.ToolBarButton.switchButtonImageSize,
                     foregroundColor: .customColor(.neutral(.white))) {
-                        switchButtonTapped()
+                        onSwitchCameara()
                     }
             }
             .sharedBackgroundVisibility(.hidden)
         }
-        .toolbar(isShowBottomToolBar ? .hidden : .visible, for: .bottomBar)
+        .toolbar(isShowingBottomToolBar ? .hidden : .visible, for: .bottomBar)
     }
 }
 

--- a/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/LiveCameraView.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/View/LiveCameraView.swift
@@ -1,0 +1,93 @@
+//
+//  CameraLiveView.swift
+//  FeatureRecordPhoto
+//
+//  Created by 정지훈 on 9/29/25.
+//
+
+import SwiftUI
+import SharedDesignSystem
+import CoreCaptureSessionInterface
+
+struct LiveCameraView: View {
+    let isAuthorized: Bool
+    let isShowTutorialAlert: Bool
+    let sessionManager: CaptureSessionable
+    let onCapture: () -> Void
+    let onTutorialOK: () -> Void
+
+    var body: some View {
+        ZStack {
+            VStack(spacing: Constant.RootVStack.spacing) {
+                if !isShowTutorialAlert {
+                    Text(Constant.ExplainText.text)
+                        .foregroundStyle(Color.customColor(.neutral(.white)))
+                        .padding(.top, Constant.ExplainText.topPadding)
+                }
+
+                if isAuthorized {
+                    CameraPreview(session: session)
+                }
+
+                Spacer()
+
+                Button(action: onCapture) {
+                    Circle()
+                        .stroke(Color.customColor(.neutral(.darkGray)),
+                                lineWidth: Constant.CaptureButton.lineWidth)
+                        .fill(Color.customColor(.neutral(.white)))
+                        .frame(width: Constant.CaptureButton.size,
+                               height: Constant.CaptureButton.size)
+                }
+            }
+
+            if isAuthorized && isShowTutorialAlert {
+                NOAlertView(
+                    title: Constant.AlertView.title,
+                    image: NOImage.normal(.recordPhoto(.recordPhotoExpain)).image,
+                    buttonText: Constant.AlertView.buttonTitle
+                ) {
+                    withAnimation(.easeInOut(duration: Constant.AlertView.animationDuration)) {
+                        onTutorialOK()
+                    }
+                }
+                .zIndex(1)
+            }
+        }
+    }
+}
+
+extension CameraLiveView {
+    fileprivate enum Constant {
+        enum RootVStack {
+            static let spacing: CGFloat = 10
+        }
+        
+        enum ExplainText {
+            static let text: String = "옷이 잘 보이도록 사진을 찍어주세요"
+            static let topPadding: CGFloat = 20
+        }
+        
+        enum CameraPreview {
+            static let topPadding: CGFloat = 10
+        }
+        
+        enum CaptureButton {
+            static let lineWidth: CGFloat = 10
+            static let size: CGFloat = 60
+        }
+        
+        enum AlertView {
+            static let title: String = "옷이 잘 보이도록 사진을 찍어주세요!"
+            static let buttonTitle: String = "확인"
+            static let animationDuration: TimeInterval = 0.2
+        }
+        
+        enum ToolBarButton {
+            static let xButtonimageName: String = "xmark"
+            static let xButtonImageSize: CGSize = .init(width: 18, height: 18)
+            static let switchButtonimageName: String = "arrow.trianglehead.2.clockwise.rotate.90"
+            static let switchButtonImageSize: CGSize = .init(width: 26, height: 22)
+        }
+    }
+}

--- a/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/ViewModel/CaptureCameraViewModel.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/ViewModel/CaptureCameraViewModel.swift
@@ -21,6 +21,8 @@ final class CaptureCameraViewModel {
         case xButtonTapped
         case switchButtonTapped
         case tutorialOkButtonTapped
+        case retakeButtonTapped
+        case usePhotoButtonTapped
     }
     
     // MARK: - Output
@@ -31,6 +33,7 @@ final class CaptureCameraViewModel {
         var isAuthorized: Bool = false
         var capturedImage: UIImage?
         var isFrontCamera: Bool = false
+        var isShowBottomToolBar: Bool { isShowTutorialAlert || capturedImage != nil }
     }
     
     private(set) var output: Output
@@ -55,8 +58,10 @@ final class CaptureCameraViewModel {
         case .captureButtonTapped:
             Task { [manager = captureSessionManager] in
                 do {
+                    Log.debug("123")
                     let data = try await manager.capturePhoto()
                     output.capturedImage = UIImage(data: data)
+                    Log.debug("456")
                 } catch {
                     Log.error("CaptureCameraError")
                 }
@@ -71,6 +76,11 @@ final class CaptureCameraViewModel {
             }
         case .tutorialOkButtonTapped:
             output.isShowTutorialAlert = false
+            
+        case .retakeButtonTapped:
+            break
+        case .usePhotoButtonTapped:
+            break
         }
     }
 }

--- a/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/ViewModel/CaptureCameraViewModel.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/ViewModel/CaptureCameraViewModel.swift
@@ -23,20 +23,25 @@ final class CaptureCameraViewModel {
         case tutorialOkButtonTapped
         case retakeButtonTapped
         case usePhotoButtonTapped
+        case errorAlertButtonTapped
     }
     
     // MARK: - Output
     
     struct Output {
         @UserDefaultsWrapper(key: "isShowTutorialAlert", defaultValue: true)
-        var isShowTutorialAlert: Bool
+        var isShowingTutorialAlert: Bool
+        var isShowingErrorAlet: Bool = false
         var isAuthorized: Bool = false
         var capturedImage: UIImage?
-        var isFrontCamera: Bool = false
-        var isShowBottomToolBar: Bool { isShowTutorialAlert || capturedImage != nil }
+        var isShowingBottomToolBar: Bool { isShowingTutorialAlert || capturedImage != nil }
     }
     
-    private(set) var output: Output
+    var output: Output
+    
+    // MARK: - Private Properties
+    
+    private var isFrontCamera: Bool = false
     
     // MARK: - Dependencies
     
@@ -61,7 +66,8 @@ final class CaptureCameraViewModel {
                     let data = try await manager.capturePhoto()
                     output.capturedImage = UIImage(data: data)
                 } catch {
-                    Log.error("CaptureCameraError")
+                    output.isShowingErrorAlet = true
+                    Log.error("CaptureCameraError: \(error.localizedDescription)")
                 }
             }
             
@@ -69,18 +75,21 @@ final class CaptureCameraViewModel {
             router.dismiss()
             
         case .switchButtonTapped:
-            Task { [isFrontCamera = output.isFrontCamera, manager = captureSessionManager] in
-                output.isFrontCamera = !isFrontCamera
-                await manager.switchCamera(output.isFrontCamera)
+            Task { [manager = captureSessionManager] in
+                isFrontCamera.toggle()
+                await manager.switchCamera(isFrontCamera)
             }
         case .tutorialOkButtonTapped:
-            output.isShowTutorialAlert = false
+            output.isShowingTutorialAlert = false
             
         case .retakeButtonTapped:
             output.capturedImage = nil
             
         case .usePhotoButtonTapped:
             router.push(RecordPhotoRoute.validatePhoto)
+            
+        case .errorAlertButtonTapped:
+            router.dismiss()
         }
     }
 }

--- a/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/ViewModel/CaptureCameraViewModel.swift
+++ b/NalssiOtjang/Feature/RecordPhoto/Sources/RecordPhoto/CaptureCameraView/ViewModel/CaptureCameraViewModel.swift
@@ -58,14 +58,13 @@ final class CaptureCameraViewModel {
         case .captureButtonTapped:
             Task { [manager = captureSessionManager] in
                 do {
-                    Log.debug("123")
                     let data = try await manager.capturePhoto()
                     output.capturedImage = UIImage(data: data)
-                    Log.debug("456")
                 } catch {
                     Log.error("CaptureCameraError")
                 }
             }
+            
         case .xButtonTapped:
             router.dismiss()
             
@@ -78,9 +77,10 @@ final class CaptureCameraViewModel {
             output.isShowTutorialAlert = false
             
         case .retakeButtonTapped:
-            break
+            output.capturedImage = nil
+            
         case .usePhotoButtonTapped:
-            break
+            router.push(RecordPhotoRoute.validatePhoto)
         }
     }
 }


### PR DESCRIPTION
## #️⃣이슈 번호
#13 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요(필요시 스크린샷/영상 첨부)
- CapturedCameraView UI 및 기능(다시찍기, 사진사용) 구현
`사진 사용의 경우 EmptyView로 이동만 임시 구현`
- 기존 CaptureCameraView를 LiveCameraView, CapturedCameraView로 분리

https://github.com/user-attachments/assets/2f23ee87-9d4b-4005-b0ba-b6315dd3b357




